### PR TITLE
Mark Kumo as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application will no longer be distributed through Flathub, please check its source for build instructions."
+}


### PR DESCRIPTION
Considering the effort required to ship Flatpaks, combined with Flathub actively blocking mobile-first applications, it seems that this is not an appropriate distribution format for software.